### PR TITLE
[bugfix] Rename job in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Build
 on: [push, pull_request]
 
 jobs:
-  assemble:
+  build:
     name: Build and Test
     strategy:
       fail-fast: false


### PR DESCRIPTION
The job name should be `build`